### PR TITLE
Automate Deployment for Dune 2 Lite Web

### DIFF
--- a/.github/prompts/prompts.md
+++ b/.github/prompts/prompts.md
@@ -1,7 +1,7 @@
 # getting started with a the next task
 ## getting the issue ready
 please take the next task in the roadmap that does not have a linked issue and create a github issue for it using ghcli
-before running command show me the title and description you plan to set for the issue (make sure the description doesn't break the markdown formatting)
+before running command show me the title and description you plan to set for the issue (make sure the description doesn't break the markdown formatting and uses proper newlines)
 ## connect issue to roadmap
 now please take that issue and link it in the roadmap
 ## create a branch

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dune 2 Lite (Web)
 
+![Deploy to GitHub Pages](https://github.com/OfirYaron/dune2-web/actions/workflows/deploy.yml/badge.svg)
+
 A simplified web-based real-time strategy (RTS) game inspired by Dune 2. The game runs entirely in the browser using HTML5 Canvas and JavaScript.
 See latest deployed game here: https://ofiryaron.com/dune2-web/
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -21,7 +21,7 @@ This roadmap outlines a comprehensive, step-by-step plan to transform Dune 2 Lit
 4. **Set Up GitHub Actions CI** [Issue](https://github.com/OfirYaron/dune2-web/issues/10)
    - Run tests and linting on every push and PR.
    - Fail builds on test or lint errors.
-5. **Automate Deployment**
+5. **Automate Deployment** [Issue](https://github.com/OfirYaron/dune2-web/issues/12)
    - Use GitHub Pages (or similar) for auto-deployment on main branch updates.
    - Add deployment status badge to README.
 


### PR DESCRIPTION
## Implementation Plan

1. Set up GitHub Actions workflow to deploy the site to GitHub Pages on every push to the main branch.
2. Configure the workflow to build and publish the static site from the repository root.
3. Add a deployment status badge to the top of the README for visibility.
4. Test the workflow by pushing a change to the main branch and verifying deployment.

Linked Issue: #12